### PR TITLE
Always force upload

### DIFF
--- a/src/publish.jl
+++ b/src/publish.jl
@@ -27,7 +27,7 @@ function publish(vm::RudeOil.MachineEnv, publisher::Publisher, package::Abstract
     `gpg --allow-secret-key-import --import secret-$gpgkey.asc`
     `gpg --import $gpgkey.asc`
     `debsign --re-sign $(debname)_source.changes -k $gpgkey`
-    `dput ppa:$(publisher.id)/$(publisher.ppa) $(debname)_source.changes`
+    `dput -f ppa:$(publisher.id)/$(publisher.ppa) $(debname)_source.changes`
   ] |> run
 end
 publish(machine::RudeOil.AbstractMachine, args...) = publish(activate(machine), args...)


### PR DESCRIPTION
I had a failed build because I didn't create the correct Launchpad channel before building. After correcting that dput refused to upload since the file had already been uploaded. This is a know bug 
See bottom of https://help.launchpad.net/Packaging/UploadErrors 

One can either delete the .upload file before uploading or use the force flag. The later seems like the simplest solution
